### PR TITLE
fix nl2br

### DIFF
--- a/transporte/views.py
+++ b/transporte/views.py
@@ -375,7 +375,7 @@ def format_datetime(value):
     return babel.dates.format_datetime(value, format)
 
 
-_paragraph_re = re.compile(r'(?:\r\n|\r|\n){2,}')
+_paragraph_re = re.compile(r'(?:\r\n|\r|\n)')
 
 
 @evalcontextfilter


### PR DESCRIPTION
The splitting was done incorrect. It split only if 2 newlines (or \n\r since this are 2 chars in the set, but not matched on '\n\r').
The regular expression from the snippet at https://jinja.palletsprojects.com/en/2.10.x/api/#custom-filters was intended to make paragraphes from text where 2 newlines shall create a new paragraph. the replacing of newlines inside the paragraph was done using a replace.

For some reason, this worked in the comment field, but not in the address field.