### PR TITLE
Add the ability to configure accounts with password.

### DIFF
--- a/transporte/config.cfg.example
+++ b/transporte/config.cfg.example
@@ -7,6 +7,12 @@ UPLOAD_DIR = 'uploads'
 SQLALCHEMY_DATABASE_URI = 'sqlite:///app.db'
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+#The passwords in this list need to be unique.
+#Login via /login/password/<password>
+SPECIAL_HELPDESK_ACCOUNTS = [{
+    'email': 'mail@exmaple.com',
+    'password': 'secret'
+}]
 
 # mail server config
 MAIL_SERVER = 'SMTP_HOST'


### PR DESCRIPTION
This can be used for helpdesk laptops, for which there is no e-mail address.
These accounts must be added to the config with a mail and a password.
To login the url /login/password/<password> is used.

Solves: #21