### PR TITLE
Remove check for date to be in the future.

### DIFF
--- a/transporte/forms.py
+++ b/transporte/forms.py
@@ -41,7 +41,7 @@ class TransportForm(FlaskForm):
     origin = TextAreaField('Origin', validators=[DataRequired()])
     destination = TextAreaField('Destination', validators=[DataRequired()])
     date = DateField('Date', validators=[DataRequired(), DateRange(
-        min=max(datetime.date.today(), datetime.date(year=2019, month=12, day=14)),
+        min=datetime.date(year=2019, month=12, day=14),
         max=datetime.date(year=2020, month=1, day=7))])
     time = TimeField('ETA', validators=[Optional()])
     vehicle = SelectField('Vehicle', validators=[DataRequired()], choices=[('', '')] + list(VehicleTypes.items()))


### PR DESCRIPTION
This check causes transports in the past to not be editable.
This check is not very necessary.

Fixes #25